### PR TITLE
fix: third page 화면 구성 수정

### DIFF
--- a/lib/config/gaps.dart
+++ b/lib/config/gaps.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/cupertino.dart';
 
 class Gaps {
+  static const spacer = Spacer();
+
   static const gapW5 = SizedBox(width: 5,);
   static const gapW10 = SizedBox(width: 10,);
   static const gapW15 = SizedBox(width: 15,);

--- a/lib/ui/third/third_menu_list.dart
+++ b/lib/ui/third/third_menu_list.dart
@@ -16,29 +16,26 @@ class MenuList extends StatelessWidget {
       Icons.question_mark_outlined
     ];
 
-    return SizedBox(
-      height: MediaQuery.of(context).size.height * 0.7,
-      child: ListView.builder(
-          itemCount: menuList.length,
-          itemBuilder: (context, index) {
-            return InkWell(
-              onTap: (){},
-              child: Padding(
-                padding: const EdgeInsets.all(10.0),
-                child: Row(
-                  children: [
-                    Icon(menuIcons[index]),
-                    Gaps.gapW10,
-                    Text(
-                      menuList[index],
-                      style: MyText.fontSize17,
-                    ),
-                  ],
-                ),
+    return Column(
+      children: [
+        for( int i = 0; i < menuList.length; i++ )
+          InkWell(
+            onTap: (){},
+            child: Padding(
+              padding: const EdgeInsets.all(15.0),
+              child: Row(
+                children: [
+                  Icon(menuIcons[i]),
+                  Gaps.gapW10,
+                  Text(
+                    menuList[i],
+                    style: MyText.fontSize17,
+                  )
+                ],
               ),
-            );
-          }
-      ),
+            ),
+          )
+      ],
     );
   }
 }

--- a/lib/ui/third/third_page.dart
+++ b/lib/ui/third/third_page.dart
@@ -8,13 +8,8 @@ class ThirdPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        centerTitle: true,
-        title: const Text('ThirdPage'),
-      ),
-
-      body: const SingleChildScrollView(
+    return const Scaffold(
+      body: SingleChildScrollView(
         child: Column(
           children: [
             UserProfile(),

--- a/lib/ui/third/third_user_profile.dart
+++ b/lib/ui/third/third_user_profile.dart
@@ -9,51 +9,55 @@ class UserProfile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: const EdgeInsets.all(15.0),
+      padding: const EdgeInsets.all(20.0),
       height: MediaQuery.of(context).size.height * 0.4,
       color: Colors.amberAccent,
-      child: Column(
-        children: [
-          // 사용자 프로필
-          userProfile(context),
+      child: Center(
+        child: Column(
+          children: [
+            Gaps.spacer,
 
-          // 사용자 메뉴 리스트
-          privateMenuList()
-        ],
+            // 사용자 프로필
+            userProfile(context),
+
+            Gaps.spacer,
+
+            // 사용자 메뉴 리스트(주문 내역, 리뷰 관리, 나의 찜)
+            privateMenuList()
+          ],
+        ),
       ),
     );
   }
 
   // 사용자 프로필
   Widget userProfile(BuildContext context) {
-    return Expanded(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          // 프로필 사진
-          ClipRRect(
-            borderRadius: BorderRadius.circular(125),
-            child: Image.asset(
-              'assets/images/sample2.png',
-              width: MediaQuery.of(context).size.width * 0.3,
-            ),
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        // 프로필 사진
+        ClipRRect(
+          borderRadius: BorderRadius.circular(125),
+          child: Image.asset(
+            'assets/images/sample2.png',
+            width: MediaQuery.of(context).size.width * 0.3,
           ),
+        ),
 
-          Gaps.gapH10,
+        Gaps.gapH10,
 
-          // 이름
-          Text(
-            '김창영 님',
-            style: TextStyle(
-                fontSize: 20.0
-            ),
-          )
-        ],
-      ),
+        // 이름
+        Text(
+          '김창영 님',
+          style: TextStyle(
+              fontSize: 20.0
+          ),
+        )
+      ],
     );
   }
 
-  // 사용자 메뉴 리스트
+  // 사용자 메뉴 리스트(주문 내역, 리뷰 관리, 나의 찜)
   Widget privateMenuList() {
     return const Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,


### PR DESCRIPTION
## 💡 Motivation

- third page 화면 구성 수정

<br>

## 🛠️ Key Changes

- appBar 제거
- ListView()가 하단의 공지사항, 약관 등의 메뉴에만 적용되어 있던 부분을 전체에 적용되도록 수정

<br>

## 📸 Screenshot

<img width="450" alt="image" src="https://github.com/backtothefuture-team/backToTheFuture-frontend/assets/73895803/6331d879-db99-44c5-a43f-f3f6d1e8e8f2">

<br>

## 📝 To Reviewers

각 이미지들을 사용자가 가진 이미지의 크기에 상관없이 동일한 사이즈가 들어올 수 있도록 해야함.
이 부분에 대해 여러 사이즈의 이미지를 대입해보는 테스트 필요.
또한 이미지들은 모두 둥근 원형임.