### PR TITLE
refactor: store_info_page class 코드 분할

### DIFF
--- a/lib/ui/first/store_list.dart
+++ b/lib/ui/first/store_list.dart
@@ -17,7 +17,7 @@ class StoreList extends StatelessWidget {
           onTap: (){
             print('가게 클릭 : $index');
             Navigator.push(context, MaterialPageRoute(
-                builder: (context) => StoreInfo(selectedStoreIndex: index,)
+                builder: (context) => StoreInfoPage(selectedStoreIndex: index,)
             ));
           },
 

--- a/lib/ui/store_info/store_info.dart
+++ b/lib/ui/store_info/store_info.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+import '../../config/gaps.dart';
+
+class StoreInfo extends StatelessWidget {
+  const StoreInfo({required this.selectedStoreIndex, super.key});
+
+  final int selectedStoreIndex;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        // 가게 정보
+        storeInfo(selectedStoreIndex),
+
+        // 찜, 길찾기, 공유 버튼
+        placeMenus(),
+      ],
+    );
+  }
+
+  // 가게 정보
+  Widget storeInfo(int selectedStoreIndex) {
+    return Padding(
+      padding: EdgeInsets.all(15.0),
+      child: Column(
+        children: [
+
+          // 가게명
+          Text(
+            '참바른빵($selectedStoreIndex)',
+            style: const TextStyle(
+              fontSize: 20.0,
+              fontWeight: FontWeight.bold
+            ),
+          ),
+
+          // 리뷰
+          Text('97%(21) 리뷰 16개 >'),
+
+          Divider(color: Colors.grey,),
+
+          // 픽업 가능 시간
+          const Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(CupertinoIcons.clock),
+              Gaps.gapW5,
+              Text('픽업 가능'),
+              Gaps.gapW5,
+              Text('오후 8:00 ~ 오후 8:30')
+            ],
+          ),
+
+          // 가게 주소
+          const Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(CupertinoIcons.location_solid),
+              Gaps.gapW5,
+              Text('서울특별시 종로구 명륜3가\n성균관로 1길 6-6, 1층'),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+
+  // 찜, 길찾기, 공유 메뉴 버튼들
+  Widget placeMenus() {
+    return const Padding(
+      padding: EdgeInsets.all(15.0),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Row(
+            children: [
+              Icon(CupertinoIcons.heart),
+              Text('75'),
+            ],
+          ),
+
+          Text('|'),
+
+          Row(
+            children: [
+              Icon(CupertinoIcons.arrow_swap),
+              Text('길찾기'),
+            ],
+          ),
+
+          Text('|'),
+
+          Row(
+            children: [
+              Icon(CupertinoIcons.share),
+              Text('공유'),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/store_info/store_info_page.dart
+++ b/lib/ui/store_info/store_info_page.dart
@@ -2,9 +2,10 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:rest_api_ex/config/gaps.dart';
 import 'package:rest_api_ex/ui/first/food_list.dart';
+import 'package:rest_api_ex/ui/store_info/store_info.dart';
 
-class StoreInfo extends StatelessWidget {
-  const StoreInfo({required this.selectedStoreIndex, super.key});
+class StoreInfoPage extends StatelessWidget {
+  const StoreInfoPage({required this.selectedStoreIndex, super.key});
 
   final int selectedStoreIndex;
 
@@ -23,11 +24,9 @@ class StoreInfo extends StatelessWidget {
                 children: [
 
                   // 가게 정보
-                  storeInfo(selectedStoreIndex),
+                  StoreInfo(selectedStoreIndex: selectedStoreIndex),
 
-                  // 찜, 길찾기, 공유 버튼
-                  placeMenus(),
-
+                  // 메뉴 정보
                   FoodList()
                 ],
               ),
@@ -47,89 +46,6 @@ class StoreInfo extends StatelessWidget {
           'assets/images/sample.png',
           fit: BoxFit.cover,
         ),
-      ),
-    );
-  }
-
-  // 가게 정보
-  Widget storeInfo(int selectedStoreIndex) {
-   return Padding(
-     padding: EdgeInsets.all(15.0),
-     child: Column(
-       children: [
-
-         // 가게명
-         Text(
-           '참바른빵($selectedStoreIndex)',
-           style: TextStyle(
-               fontSize: 20.0,
-               fontWeight: FontWeight.bold
-           ),
-         ),
-
-         // 리뷰
-         Text('97%(21) 리뷰 16개 >'),
-
-         Divider(color: Colors.grey,),
-
-         // 픽업 가능 시간
-         const Row(
-           mainAxisAlignment: MainAxisAlignment.center,
-           children: [
-             Icon(CupertinoIcons.clock),
-             Gaps.gapW5,
-             Text('픽업 가능'),
-             Gaps.gapW5,
-             Text('오후 8:00 ~ 오후 8:30')
-           ],
-         ),
-
-         // 가게 주소
-         Row(
-           mainAxisAlignment: MainAxisAlignment.center,
-           children: [
-             Icon(CupertinoIcons.location_solid),
-             Gaps.gapW5,
-             Text('서울특별시 종로구 명륜3가\n성균관로 1길 6-6, 1층'),
-           ],
-         ),
-       ],
-     ),
-   );
-  }
-
-  // 찜, 길찾기, 공유 메뉴 버튼들
-  Widget placeMenus() {
-    return const Padding(
-      padding: EdgeInsets.all(15.0),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          Row(
-            children: [
-              Icon(CupertinoIcons.heart),
-              Text('75'),
-            ],
-          ),
-
-          Text('|'),
-
-          Row(
-            children: [
-              Icon(CupertinoIcons.arrow_swap),
-              Text('길찾기'),
-            ],
-          ),
-
-          Text('|'),
-
-          Row(
-            children: [
-              Icon(CupertinoIcons.share),
-              Text('공유'),
-            ],
-          ),
-        ],
       ),
     );
   }


### PR DESCRIPTION
## 💡 Motivation

- 기존 StoreInfo class(store_info_page.dart)의 이름을 StoreInfoPage 로 변경
- 새 StoreInfo class 생성
- StoreInfo class에 있던 가게 정보 코드들을 새 StoreInfo class로 이동

<br>

## 🛠️ Key Changes

-

<br>

## 📸 Screenshot

<img width="216" alt="image" src="https://github.com/backtothefuture-team/backToTheFuture-frontend/assets/73895803/53fb2ecb-7d92-409b-ac8e-580ca549ed8e">

<br></br>

* store_info_page.dart  
<img width="451" alt="image" src="https://github.com/backtothefuture-team/backToTheFuture-frontend/assets/73895803/90310608-e115-4619-ac27-e4f6a66cdecf">

<br>

## 📝 To Reviewers
