### PR TITLE
feat: sign up UI

### DIFF
--- a/lib/config/gaps.dart
+++ b/lib/config/gaps.dart
@@ -9,4 +9,5 @@ class Gaps {
 
   static const gapH5 = SizedBox(height: 5,);
   static const gapH10 = SizedBox(height: 10,);
+  static const gapH20 = SizedBox(height: 20,);
 }

--- a/lib/config/my_validator.dart
+++ b/lib/config/my_validator.dart
@@ -1,0 +1,16 @@
+
+String? myValidate(String? value, String field, {int? minLength, bool confirmPassword = false, String? userPassword}) {
+  if( value == null || value.isEmpty ) {
+    return '$field을(를) 입력해 주세요.';
+  }
+
+  if( minLength != null && value.length < minLength ) {
+    return '$field는 $minLength자리 이상 입력해 주세요.';
+  }
+
+  if( confirmPassword && value != userPassword ) {
+    return '비밀번호가 일치하지 않습니다.';
+  }
+
+  return null;
+}

--- a/lib/config/navigate_to.dart
+++ b/lib/config/navigate_to.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+void navigateTo(BuildContext context, Widget where) {
+  Navigator.push(
+    context,
+    MaterialPageRoute(builder: (context) => where),
+  );
+}
+
+
+void navigatePushAndRemoveUtilTo(BuildContext context, Widget where) {
+  Navigator.pushAndRemoveUntil(
+    context,
+    MaterialPageRoute(builder: (context) => where),
+    (route) => false,
+  );
+}

--- a/lib/config/palette.dart
+++ b/lib/config/palette.dart
@@ -1,0 +1,10 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+
+class Palette {
+  static const primaryColor = Color.fromARGB(255, 110, 211, 169);
+
+  // text color
+  static const whiteTextColor = Colors.white;
+}

--- a/lib/config/palette.dart
+++ b/lib/config/palette.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 
 class Palette {
   static const primaryColor = Color.fromARGB(255, 110, 211, 169);
+  static const disabledColor = Color.fromARGB(255, 195, 195, 195);
 
   // text color
   static const whiteTextColor = Colors.white;

--- a/lib/config/user_info_text_form_field.dart
+++ b/lib/config/user_info_text_form_field.dart
@@ -4,11 +4,17 @@ import 'package:rest_api_ex/config/palette.dart';
 class UserInfoTextFormField extends StatelessWidget {
   const UserInfoTextFormField({
     super.key,
+    this.autoFocus,
+    this.isButtonEnabled,
+    this.textInputType,
     required this.controller,
     required this.validator,
     required this.decorationLabelText,
   });
 
+  final bool? autoFocus;
+  final bool? isButtonEnabled;
+  final TextInputType? textInputType;
   final TextEditingController? controller;
   final String? Function(String?) validator;
   final String decorationLabelText;
@@ -16,6 +22,9 @@ class UserInfoTextFormField extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return TextFormField(
+      // null 이면 autoFocus 기본 값 false
+      autofocus: autoFocus ?? false,
+      keyboardType: textInputType,
       controller: controller,
       validator: validator,
       decoration: _setTextFormDecoration(decorationLabelText),
@@ -28,11 +37,17 @@ class UserInfoTextFormField extends StatelessWidget {
       labelStyle: const TextStyle(
         color: Colors.black54,
       ),
+
+      // 이메일 인증 요청에서만 필요한 부분
+      suffixIcon: isButtonEnabled != null && isButtonEnabled == true
+          ? const Icon(Icons.check, color: Palette.primaryColor,)
+          : null,
+
       enabledBorder: const OutlineInputBorder(
         borderSide: BorderSide(
-          color: Palette.primaryColor
-        )
-      )
+          color: Palette.primaryColor,
+        ),
+      ),
     );
   }
 }

--- a/lib/config/user_info_text_form_field.dart
+++ b/lib/config/user_info_text_form_field.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:rest_api_ex/config/palette.dart';
 
-class SignUpTextFormField extends StatelessWidget {
-  const SignUpTextFormField({
+class UserInfoTextFormField extends StatelessWidget {
+  const UserInfoTextFormField({
     super.key,
     required this.controller,
     required this.validator,
@@ -27,6 +28,11 @@ class SignUpTextFormField extends StatelessWidget {
       labelStyle: const TextStyle(
         color: Colors.black54,
       ),
+      enabledBorder: const OutlineInputBorder(
+        borderSide: BorderSide(
+          color: Palette.primaryColor
+        )
+      )
     );
   }
 }

--- a/lib/ui/sign_in/sign_in.dart
+++ b/lib/ui/sign_in/sign_in.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:rest_api_ex/config/gaps.dart';
 
 import '../sign_up/sign_up.dart';
+import 'sign_in_email.dart';
 
 class SignIn extends StatelessWidget {
   const SignIn({super.key});
@@ -9,28 +11,48 @@ class SignIn extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       body: Center(
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.center,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
           children: [
-            ElevatedButton(
-              onPressed: (){
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (context) => const SignUp())
-                );
-              },
-              child: Text('회원가입')
-            ),
+            // 로고와 인사말
+            signInTitle(),
 
-            SizedBox(width: 10,),
-
-            ElevatedButton(
-              onPressed: (){},
-              child: Text('로그인')
-            )
+            // 이메일 로그인 버튼
+            emailSignInButton(context),
           ],
         ),
       ),
+    );
+  }
+
+  // 로고와 인사말
+  Widget signInTitle() {
+    return Column(
+      children: [
+        Image.asset('assets/images/btf_logo.png'),
+        Gaps.gapH20,
+        const Text(
+          '마감 세일 상품을 \n서프라이즈 백으로 만나보세요',
+          textAlign: TextAlign.center,
+          style: TextStyle(
+            fontSize: 20.0,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget emailSignInButton(BuildContext context) {
+    return ElevatedButton(
+      onPressed: () {
+        Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (context) => const EmailSignIn(),
+            ));
+      },
+      child: Text('이메일 로그인'),
     );
   }
 }

--- a/lib/ui/sign_in/sign_in_email.dart
+++ b/lib/ui/sign_in/sign_in_email.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class EmailSignIn extends StatelessWidget {
+  const EmailSignIn({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
+  }
+}

--- a/lib/ui/sign_in/sign_in_email.dart
+++ b/lib/ui/sign_in/sign_in_email.dart
@@ -1,10 +1,70 @@
 import 'package:flutter/material.dart';
+import 'package:modal_progress_hud_nsn/modal_progress_hud_nsn.dart';
+import 'package:rest_api_ex/config/gaps.dart';
+import 'package:rest_api_ex/ui/sign_in/sign_in_email_form.dart';
 
-class EmailSignIn extends StatelessWidget {
+class EmailSignIn extends StatefulWidget {
   const EmailSignIn({super.key});
 
   @override
+  State<EmailSignIn> createState() => _EmailSignInState();
+}
+
+class _EmailSignInState extends State<EmailSignIn> {
+  bool showSpinner = false;
+  final formKey = GlobalKey<FormState>();
+  final userEmailController = TextEditingController();
+  final userPasswordController = TextEditingController();
+
+  // 유효성 검사
+  void _tryValidation() {
+    final isValid = formKey.currentState!.validate();
+
+    if (isValid) {
+      formKey.currentState!.save();
+    }
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    userEmailController.dispose();
+    userPasswordController.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return const Placeholder();
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('이메일 로그인'),
+      ),
+      body: ModalProgressHUD(
+        inAsyncCall: showSpinner,
+        child: Column(
+          children: [
+            // 이메일 입력 폼, 비밀번호 입력 폼, 로그인 버튼
+            SignInEmailForm(
+              formKey: formKey,
+              userEmailController: userEmailController,
+              userPasswordController: userPasswordController,
+            ),
+
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text('비밀번호 찾기'),
+                Gaps.gapW15,
+                Text(' | '),
+                Gaps.gapW15,
+                Text(
+                  '회원가입',
+                  style: TextStyle(decoration: TextDecoration.underline),
+                ),
+              ],
+            )
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/lib/ui/sign_in/sign_in_email.dart
+++ b/lib/ui/sign_in/sign_in_email.dart
@@ -2,6 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:modal_progress_hud_nsn/modal_progress_hud_nsn.dart';
 import 'package:rest_api_ex/config/gaps.dart';
 import 'package:rest_api_ex/ui/sign_in/sign_in_email_form.dart';
+import 'package:rest_api_ex/ui/sign_up/sign_up.dart';
+
+import '../../config/navigate_to.dart';
 
 class EmailSignIn extends StatefulWidget {
   const EmailSignIn({super.key});
@@ -56,14 +59,25 @@ class _EmailSignInState extends State<EmailSignIn> {
                 Gaps.gapW15,
                 Text(' | '),
                 Gaps.gapW15,
-                Text(
-                  '회원가입',
-                  style: TextStyle(decoration: TextDecoration.underline),
-                ),
+                // 회원가입 버튼
+                signUpButton(context),
               ],
             )
           ],
         ),
+      ),
+    );
+  }
+
+  // 회원가입 버튼
+  Widget signUpButton(BuildContext context) {
+    return GestureDetector(
+      onTap: () {
+        navigateTo(context, const SignUp());
+      },
+      child: const Text(
+        '회원가입',
+        style: TextStyle(decoration: TextDecoration.underline),
       ),
     );
   }

--- a/lib/ui/sign_in/sign_in_email.dart
+++ b/lib/ui/sign_in/sign_in_email.dart
@@ -5,6 +5,7 @@ import 'package:rest_api_ex/ui/sign_in/sign_in_email_form.dart';
 import 'package:rest_api_ex/ui/sign_up/sign_up.dart';
 
 import '../../config/navigate_to.dart';
+import '../sign_up/email_auth_request.dart';
 
 class EmailSignIn extends StatefulWidget {
   const EmailSignIn({super.key});
@@ -73,7 +74,7 @@ class _EmailSignInState extends State<EmailSignIn> {
   Widget signUpButton(BuildContext context) {
     return GestureDetector(
       onTap: () {
-        navigateTo(context, const SignUp());
+        navigateTo(context, const EmailAuthRequest());
       },
       child: const Text(
         '회원가입',

--- a/lib/ui/sign_in/sign_in_email_form.dart
+++ b/lib/ui/sign_in/sign_in_email_form.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+
+import '../../config/gaps.dart';
+import '../../config/my_validator.dart';
+import '../../config/navigate_to.dart';
+import '../../config/palette.dart';
+import '../../config/user_info_text_form_field.dart';
+import '../my_bottom_navigation.dart';
+
+class SignInEmailForm extends StatelessWidget {
+  const SignInEmailForm({
+    required this.formKey,
+    required this.userEmailController,
+    required this.userPasswordController,
+    super.key});
+
+  final GlobalKey<FormState> formKey;
+
+  final TextEditingController userEmailController;
+  final TextEditingController userPasswordController;
+
+  @override
+  Widget build(BuildContext context) {
+    return Form(
+      key: formKey,
+      child: Padding(
+        padding: const EdgeInsets.all(20.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+
+          children: [
+            // 이메일
+            UserInfoTextFormField(
+              controller: userEmailController,
+              validator: (value) => myValidate(value, '이메일'),
+              decorationLabelText: '이메일을 입력해 주세요',
+            ),
+
+            Gaps.gapH20,
+
+            // 비밀번호
+            UserInfoTextFormField(
+              controller: userPasswordController,
+              validator: (value) => myValidate(value, '비밀번호'),
+              decorationLabelText: '비밀번호를 입력해 주세요',
+            ),
+
+            Gaps.gapH20,
+
+            // 로그인 버튼
+            signInButton(context),
+          ],
+        ),
+      ),
+    );
+  }
+
+  // 로그인 버튼
+  Widget signInButton(BuildContext context) {
+    return ElevatedButton(
+      style: ElevatedButton.styleFrom(
+          backgroundColor: Palette.primaryColor,
+          shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(4.0)
+          )
+      ),
+
+      onPressed: () {
+        navigatePushAndRemoveUtilTo(context, const MyBottomNavigation());
+      },
+
+      child: const Text(
+        '로그인',
+        style: TextStyle(
+            color: Palette.whiteTextColor
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/sign_in/sign_in_main_page.dart
+++ b/lib/ui/sign_in/sign_in_main_page.dart
@@ -4,8 +4,8 @@ import 'package:rest_api_ex/config/gaps.dart';
 import '../sign_up/sign_up.dart';
 import 'sign_in_email.dart';
 
-class SignIn extends StatelessWidget {
-  const SignIn({super.key});
+class MainSignInPage extends StatelessWidget {
+  const MainSignInPage({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/ui/sign_up/email_auth_request.dart
+++ b/lib/ui/sign_up/email_auth_request.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/material.dart';
+import 'package:modal_progress_hud_nsn/modal_progress_hud_nsn.dart';
+import 'package:rest_api_ex/config/gaps.dart';
+import 'package:rest_api_ex/config/my_validator.dart';
+import 'package:rest_api_ex/config/user_info_text_form_field.dart';
+
+import '../../config/palette.dart';
+
+class EmailAuthRequest extends StatefulWidget {
+  const EmailAuthRequest({super.key});
+
+  @override
+  State<EmailAuthRequest> createState() => _EmailAuthRequestState();
+}
+
+class _EmailAuthRequestState extends State<EmailAuthRequest> {
+  bool showSpinner = false;
+  bool _isButtonEnabled = false;
+  final formKey = GlobalKey<FormState>();
+  final _userEmailController = TextEditingController();
+
+  // 유효성 검사
+  void _tryValidation() {
+    final isValid = formKey.currentState!.validate();
+
+    if (isValid) {
+      formKey.currentState!.save();
+    }
+  }
+
+
+  @override
+  void initState() {
+    super.initState();
+
+    // 텍스트 길이에 따라 버튼 색상 활성화를 하기 위한 콜백 함수
+    // 함수를 호출하는 게 아니라, 콜백으로 전달하기 때문에 괄호를 사용하지 않는다.
+    _userEmailController.addListener(_updateButtonState);
+  }
+
+
+  @override
+  void dispose() {
+    super.dispose();
+    _userEmailController.dispose();
+  }
+
+
+  // 텍스트 길이에 따라 버튼 색상 활성화를 하기 위한 콜백 함수
+  void _updateButtonState() {
+    setState(() {
+      _isButtonEnabled = _userEmailController.text.length > 5;
+    });
+  }
+
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('회원가입'),
+      ),
+
+      body: ModalProgressHUD(
+        inAsyncCall: showSpinner,
+        child: SizedBox(
+          height: MediaQuery.of(context).size.height * 0.4,
+          child: Form(
+            key: formKey,
+            child: Padding(
+              padding: const EdgeInsets.all(15.0),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  // 설명 문구,
+                  description(),
+
+                  // 이메일 입력
+                  UserInfoTextFormField(
+                    autoFocus: true,
+                    isButtonEnabled: _isButtonEnabled == true ? true : false,
+                    textInputType: TextInputType.emailAddress,
+                    controller: _userEmailController,
+                    validator: (value) => myValidate(value, '이메일'),
+                    decorationLabelText: '',
+                  ),
+
+                  // 이메일 인증 요청 버튼
+                  emailAuthRequestButton(context, _isButtonEnabled)
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  // 설명 문구
+  Widget description() {
+    return const Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          '이메일을 입력해 주세요',
+          style: TextStyle(
+            fontSize: 20.0,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+
+        Gaps.gapH10,
+        Text(
+          '인증 코드를 보내드려요',
+          style: TextStyle(fontSize: 17.0,),
+        )
+      ],
+    );
+  }
+
+  // 이메일 인증 요청 버튼
+  Widget emailAuthRequestButton(BuildContext context, bool buttonEnabled) {
+    return ElevatedButton(
+      style: ElevatedButton.styleFrom(
+        backgroundColor:
+            _isButtonEnabled ? Palette.primaryColor : Palette.disabledColor,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(4.0),
+        ),
+      ),
+
+      onPressed: () {},
+
+      child: const Text(
+        '이메일 인증 요청',
+        style: TextStyle(
+          color: Palette.whiteTextColor,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/sign_up/sign_up_form.dart
+++ b/lib/ui/sign_up/sign_up_form.dart
@@ -3,7 +3,9 @@ import 'package:get_it/get_it.dart';
 import 'package:rest_api_ex/data/model/user_model.dart';
 import 'package:rest_api_ex/data/source/ErrorHandler.dart';
 import 'package:rest_api_ex/data/source/rest_client.dart';
-import 'package:rest_api_ex/ui/sign_up/sign_up_text_form_field.dart';
+import 'package:rest_api_ex/config/user_info_text_form_field.dart';
+
+import '../../config/my_validator.dart';
 
 class SignUpForm extends StatelessWidget {
   SignUpForm({
@@ -38,48 +40,48 @@ class SignUpForm extends StatelessWidget {
             children: [
 
               // 이름
-              SignUpTextFormField(
+              UserInfoTextFormField(
                 controller: userNameController,
-                validator: (value) => _validate(value, '이름'),
+                validator: (value) => myValidate(value, '이름'),
                 decorationLabelText: '이름',
               ),
 
 
               // 비밀번호
-              SignUpTextFormField(
+              UserInfoTextFormField(
                 controller: userPasswordController,
-                validator: (value) => _validate(value, '비밀번호', minLength: 6),
+                validator: (value) => myValidate(value, '비밀번호', minLength: 6),
                 decorationLabelText: '비밀번호',
               ),
 
 
               // 비밀번호 확인
-              SignUpTextFormField(
+              UserInfoTextFormField(
                 controller: null,
-                validator: (value) => _validate(value, '비밀번호', confirmPassword: true),
+                validator: (value) => myValidate(value, '비밀번호', confirmPassword: true),
                 decorationLabelText: '비밀번호 확인',
               ),
 
 
               // 휴대전화번호
-              SignUpTextFormField(
+              UserInfoTextFormField(
                 controller: userMobileNumberController,
-                validator: (value) => _validate(value, '휴대전화번호'),
+                validator: (value) => myValidate(value, '휴대전화번호'),
                 decorationLabelText: '휴대전화번호',
               ),
 
 
               // 거주지
-              SignUpTextFormField(
+              UserInfoTextFormField(
                 controller: userResidenceController,
-                validator: (value) => _validate(value, '거주지'),
+                validator: (value) => myValidate(value, '거주지'),
                 decorationLabelText: '거주지',
               ),
 
 
 
               // 프로모션 코드
-              SignUpTextFormField(
+              UserInfoTextFormField(
                 controller: promotionCodeController,
                 validator: (value) => null,
                 decorationLabelText: '프로모션 코드',
@@ -112,22 +114,4 @@ class SignUpForm extends StatelessWidget {
       )
     );
   }
-
-
-  String? _validate(String? value, String field, {int? minLength, bool confirmPassword = false}) {
-    if( value == null || value.isEmpty ) {
-      return '$field을(를) 입력해 주세요.';
-    }
-
-    if( minLength != null && value.length < minLength ) {
-      return '$field는 $minLength자리 이상 입력해 주세요.';
-    }
-
-    if( confirmPassword && value != userPasswordController.text ) {
-      return '비밀번호가 일치하지 않습니다.';
-    }
-
-    return null;
-  }
-
 }

--- a/lib/ui/third/sign_out.dart
+++ b/lib/ui/third/sign_out.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:rest_api_ex/ui/sign_in/sign_in.dart';
+import 'package:rest_api_ex/ui/sign_in/sign_in_main_page.dart';
 
 class SignOut extends StatelessWidget {
   const SignOut({super.key});
@@ -10,7 +10,7 @@ class SignOut extends StatelessWidget {
       onTap: (){
         Navigator.push(
             context,
-            MaterialPageRoute(builder: (context) => const SignIn()
+            MaterialPageRoute(builder: (context) => const MainSignInPage()
         ));
       },
 


### PR DESCRIPTION
## 💡 Motivation

- 로그인 첫 페이지 UI 간단한 구성으로 구현
- 이메일 가입 UI 구현
- 이메일 인증 요청 페이지 UI 구현

<br>

## 🛠️ Key Changes

- 회원가입 페이지와 비슷한 흐름의 코드들 refactoring
- 클래스 이름 수정 : SignIn -> MainSignInPage
- 회원가입 버튼 클릭 시 이메일 인증 요청 페이지로 이동
- 이메일 길이에 따라 버튼 색상과 아이콘 유무 구현을 위한 콜백 메서드 구현

<br>

## 📸 Screenshot

<img width="706" alt="image" src="https://github.com/backtothefuture-team/backToTheFuture-frontend/assets/73895803/36b2bb20-314e-4f46-aaa6-e4b468808fe5">

<br>

## 📝 To Reviewers

- 이메일 유효성 검사 코드 적용 및 테스트 필요
- TextFormField()의 focusedBorder() UI 추가